### PR TITLE
Install python3-pip on fedora

### DIFF
--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -20,7 +20,7 @@ RUN set -ex \
         openblas openblas-devel \
         protobuf protobuf-devel \
         tesseract tesseract-langpack-por tesseract-devel \
-        python3-numpy python3-devel \
+        python3-numpy python3-devel python3-pip \
         kernel-headers \
     && wget -q https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.zip -O opencv.zip \
     && wget -q https://github.com/opencv/opencv_contrib/archive/${OPENCV_VERSION}.zip -O opencv_contrib.zip \


### PR DESCRIPTION
Just a quick fix for this:
```
$ docker run -it hdgigante/python-opencv bash
[root@eb3bd28dff9f build]# pip
bash: pip: command not found
[root@eb3bd28dff9f build]# pip3
bash: pip3: command not found
```